### PR TITLE
Remove certly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ API | Description | Auth | HTTPS | Link | Free / Commercial|
 | Bluecoat Site Review | URL Analysis | `none` | Yes | [Link!](https://sitereview.bluecoat.com/sitereview.jsp) |Free|
 | bgpmon.net | Bgp monitoring | `?` | Yes | [Link!](https://bgpmon.net/bgpmon-web-services-api/) |?|
 | censys.io | Free for Researchers Threat Intel  | `apiKey` | Yes | [Link!](https://censys.io/api) |?|
-| Certly | Certly Guard | `apiKey` | Yes | [Link!](https://guard.certly.io/) |?|
 | CIRCL CVE Search | CVE Search | `none` | Yes | [Link!](https://cve.circl.lu/api/) |Free|
 | Cloidsploit | Vuln Scanner | `apiKey` | Yes | [Link!](https://cloudsploit.com/api) |Free|
 | CrowdStrike API | TI | `apiKey` | Yes | [Link!](https://www.crowdstrike.com/blog/tech-center/get-access-crowdstrike-apis/) |NO|
@@ -119,7 +118,6 @@ API | Description | Auth | HTTPS | Link |Free / Commercial|
 |---|---|---|---|---|---|
 | Akamai | Akamai CDN | `apiKey` | Yes | [Link!](https://developer.akamai.com/api/) | Commercial |
 | AlienVault Open Threat Exchange (OTX) | IP/domain/URL reputation | `apiKey` | Yes | [Link!](https://otx.alienvault.com/api/) |?|
-| Certly | Certly Link/Domain Flagging | `apiKey` | Yes | [Link!](https://guard.certly.io/) |?|
 | Check Point APIs | Check Point APIs Homepage | `apiKey` | Yes | [Link!](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk121360) | Commercial |
 | Cisco ISE | ISE is an identity and access control policy platform | `apiKey` | Yes | [Link!](https://www.cisco.com/c/en/us/support/security/identity-services-engine/products-command-reference-list.html) |?|
 | Cisco PXGrid | Cisco Platform Exchange Grid | `apiKey` | Yes | [Link!](https://developer.cisco.com/site/pxgrid/) |?|


### PR DESCRIPTION
Certly.io is available for sale. The website has not been mirrored successfully on Archive.org [since 2016](http://web.archive.org/web/20170715000000*/https://certly.io/).

The [Github account](https://github.com/certly) and [Twitter account](https://twitter.com/certlyinc) have been silent since 2017.
